### PR TITLE
Only Employees can see fire button and use it to fire an employee

### DIFF
--- a/src/components/employees/Employee.js
+++ b/src/components/employees/Employee.js
@@ -21,7 +21,7 @@ export const Employee = ({ employee, setter }) => {
         if (employeeId) {
             defineClasses("card employee--single")
         }
-        resolveResource(employee, employeeId, EmployeeRepository.get)
+        resolveResource(employee, employeeId, EmployeeRepository.get) //(property, param, getter function)
     }, [])
 
     useEffect(() => {
@@ -49,7 +49,7 @@ export const Employee = ({ employee, setter }) => {
                     }
                 </h5>
                 {
-                    employeeId //ternary statement 
+                    employeeId //ternary statement and param to be passed through resource to access employees
                         ? <>
                             <section>
                                 Caring for 0 animals
@@ -61,28 +61,20 @@ export const Employee = ({ employee, setter }) => {
                         : ""
                 }
                 {
+                    getCurrentUser().employee //get current signed in user and if employee key is true then show 
+                    // fire button
+                    ? //another ternary statement for the fire button
                     <button className="btn--fireEmployee" onClick={() => {
                         
                         EmployeeRepository.delete(resource.id ) //fetch call to delete employee when fire button is clicked
-                        .then(() => EmployeeRepository.getAll().then(setter))
-                        .then(()=> history.push("/employees"))
+                        .then(() => EmployeeRepository.getAll().then(setter))//setter function to give this module access to employees that are set in different module
+                        .then(()=> history.push("/employees"))//this takes user back to employees page after firing from profile
                         
                     }}>Fire</button>
-                
+                    : "" //else show nothing if user is not an employee
         }
             </section>
 
         </article>
     )
 }
-//{
-//     getCurrentUser().employee
-//     ? ""
-//     : <div className="centerChildren btn--newResource">
-//         <button type="button"
-//             className="btn btn-success "
-//             onClick={() => { history.push("/animals/new") }}>
-//             Register Animal
-//         </button>
-//     </div>
-// }


### PR DESCRIPTION
# Description
When a user is logged in and is an employee, they can see the "fire" button and click it. Once clicked, the employee card is removed from page and API.

Fixes #2 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Sign in as an employee and click on fire button. Sign out and sign back in as an owner and "fire" button will not be displayed.

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
