### PR TITLE
Animals showing caretakers and owners.

### DIFF
--- a/src/components/animals/Animal.js
+++ b/src/components/animals/Animal.js
@@ -84,13 +84,17 @@ export const Animal = ({ animal, syncAnimals,
                         <section>
                             <h6>Caretaker(s)</h6>
                             <span className="small">
-                                Unknown
+                                {animal.animalCaretakers.map((caretaker) =>{
+                                    return caretaker.user.name
+                                }).join(", ")}
                             </span>
 
 
                             <h6>Owners</h6>
                             <span className="small">
-                                Owned by 
+                                {animal.animalOwners.map((owner) =>{
+                                    return owner.user.name
+                                }).join(", ")} 
                             </span>
 
                             {

--- a/src/components/animals/AnimalList.js
+++ b/src/components/animals/AnimalList.js
@@ -76,6 +76,7 @@ export const AnimalListComponent = (props) => {
                             syncAnimals={syncAnimals}
                             setAnimalOwners={setAnimalOwners}
                             showTreatmentHistory={showTreatmentHistory}
+                            
                         />)
                 }
             </ul>


### PR DESCRIPTION
This pull will show the caretakers the current animal has on their card along with the owners name that is assigned to them.

Fixes Ticket #1 and Ticket #13 

## Type of change

Please delete options that are not relevant.


- [ x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?
- [ x] Test A
npm start and once you click on the animals tab, click on a specific animal and you should see the appropriate data.

# Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings
